### PR TITLE
Use a default and simplify configure_file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Initialize gbdxversion.h
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/gbdxmVersion.h.in ${CMAKE_CURRENT_BINARY_DIR}/include/gbdxmVersion.h)
+configure_file(gbdxmVersion.h.in include/gbdxmVersion.h)
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
 
 add_executable(gbdxm

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,8 @@ else()
 endif()
 
 # Initialize gbdxversion.h
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/gbdxmVersion.h.in ${CMAKE_BINARY_DIR}/include/gbdxmVersion.h)
-include_directories(${CMAKE_BINARY_DIR}/include)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/gbdxmVersion.h.in ${CMAKE_CURRENT_BINARY_DIR}/include/gbdxmVersion.h)
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
 
 add_executable(gbdxm
         src/main.cpp


### PR DESCRIPTION
Updates so that the generated headers and copied ones are consistent with other projects:

 - All generated headers are placed in `include` (which is relative to `${CMAKE_CURRENT_BINARY_DIR`)
 - There was no change: Projects which have generated private headers should add `${CMAKE_CURRENT_BINARY_DIR}/include` to the path.